### PR TITLE
fix travis badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [npm-image]: https://img.shields.io/npm/v/eslint-to-esformatter.svg?style=flat-square
 [npm-url]: https://www.npmjs.com/package/eslint-to-esformatter
 [travis-image]: https://img.shields.io/travis/flet/eslint-to-esformatter.svg?style=flat-square
-[travis-url]: https://travis-ci.org/flet/eslint-to-esformatter
+[travis-url]: https://travis-ci.org/Flet/eslint-to-esformatter
 
 convert .eslintrc into esformatter json
 


### PR DESCRIPTION
TIL case matters for Travis-CI URLs.

See https://travis-ci.org/flet/eslint-to-esformatter vs https://travis-ci.org/Flet/eslint-to-esformatter.
